### PR TITLE
Find pg_dump if not in the provided path

### DIFF
--- a/jobs/db-backup/templates/backup
+++ b/jobs/db-backup/templates/backup
@@ -2,6 +2,8 @@
 
 set -e
 
-PATH=/var/vcap/packages/postgres-unknown/bin:/var/vcap/packages/postgresql_9.3/bin:$PATH
+PG_FOLDER=dirname `find -L /var/vcap/jobs/db-backup -name pg_dump -print`
+
+PATH=/var/vcap/packages/postgres-unknown/bin:/var/vcap/packages/postgresql_9.3/bin:$PG_FOLDER:$PATH
 
 pg_dump --user=atc --format=custom atc > $BBR_ARTIFACT_DIRECTORY/atc.backup

--- a/jobs/db-backup/templates/restore
+++ b/jobs/db-backup/templates/restore
@@ -2,6 +2,8 @@
 
 set -e
 
-PATH=/var/vcap/packages/postgres-unknown/bin:/var/vcap/packages/postgresql_9.3/bin:$PATH
+PG_FOLDER=dirname `find -L /var/vcap/jobs/db-backup -name pg_restore -print`
+
+PATH=/var/vcap/packages/postgres-unknown/bin:/var/vcap/packages/postgresql_9.3/bin:$PG_FOLDER:$PATH
 
 pg_restore --user=atc --format=custom --schema=public --clean --dbname=atc $BBR_ARTIFACT_DIRECTORY/atc.backup 


### PR DESCRIPTION
Newer postgres packages put pg_dump in a different location and the
package naming scheme has changed slightly. So that we don't have to
change this with every version of postgres that comes out, we'll search
for pg_dump and add that to the path. Leaves the old path alone for
backwards compat although it is probably not needed.